### PR TITLE
Adds Laravel Horizon v2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/horizon": "^1.0",
+        "laravel/horizon": "^1.0|^2.0",
         "laravel/nova": "*"
     },
     "autoload": {


### PR DESCRIPTION
Laravel Horizon [v2.0.0](https://github.com/laravel/horizon/releases/tag/v2.0.0) was just released.

This PR updates the `composer.json` to reflect this.