### PR TITLE
fix: Error when upgrade to nova 3.19.0

### DIFF
--- a/src/HorizonLink.php
+++ b/src/HorizonLink.php
@@ -14,8 +14,6 @@ class HorizonLink extends Tool
 
     public function __construct(?string $label = 'Horizon Queues', string $target = 'self')
     {
-        parent::__construct();
-
         $this->label = $label;
         $this->target = $target;
     }


### PR DESCRIPTION
`__construct` not used in Tool now.

@ref https://github.com/laravel/nova/commit/29b93098e5d735920117a8274da6585aa35f2d40