### PR TITLE
Added menu method to HorizonLink class

### DIFF
--- a/src/HorizonLink.php
+++ b/src/HorizonLink.php
@@ -3,6 +3,7 @@
 namespace MadWeb\NovaHorizonLink;
 
 use Laravel\Horizon\Horizon;
+use Illuminate\Http\Request;
 use Laravel\Nova\Tool;
 
 class HorizonLink extends Tool
@@ -58,5 +59,15 @@ class HorizonLink extends Tool
     public static function useLogo(string $target = 'self'): self
     {
         return new static(null, $target);
+    }
+
+    /**
+    * Build the menu that renders the navigation links for the tool.
+    *
+    * @param  \Illuminate\Http\Request  $request
+    * @return mixed
+    */
+    public function menu(Request $request) {
+        return $this->renderNavigation();
     }
 }


### PR DESCRIPTION
In Nova 4 a menu method abstract was added to the Tool class.
This therefore needs to be implemented when extending the class.